### PR TITLE
feat(517): interface optimise

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,22 +10,20 @@ npm install screwdriver-notifications-base
 ```
 
 ## Interface
-This is a promise based interface for receiving Screwdriver API events and sending notification to users based on their job settings.
+This is a interface for receiving Screwdriver API events and sending notification to users based on their job settings.
 
 ### notify
 
 #### Expected Outcome
 
-Notify the the user based on their job settings, e.g. email, slack.
-
-#### Expected Promise response
-
-1. Resolves null when successfully notify the user
-1. Rejects with error if there is any
+Notify the user based on their job settings, e.g. email, slack.
 
 ## Extending
 To extend the base class, the functions to override are:
 1. `_notify`
+2. `events` (optional)
+
+Override `events` if you want to send notification based on other events.
 
 ## Testing
 

--- a/index.js
+++ b/index.js
@@ -2,32 +2,42 @@
 
 /* eslint-disable no-underscore-dangle */
 class NotificationBase {
-
     /**
      * Constructor for Build Notification
      * @method constructor
      * @param {Object}      config              Configuration specific to the plugin
-     * @param {Object}      server              API server
-     * @param {String}      eventName           Event name the notification plugin listen to
      * @return {NotificationBase}
      */
-    constructor(config, server, eventName) {
+    constructor(config) {
         this.config = config;
-        this.server = server;
-        this.eventName = eventName;
+    }
+
+    /**
+     * Get event list for receiving Screwdriver API events
+     * @getter events
+     * @return {Array}
+     */
+    get events() {
+        return ['build_status'];
     }
 
     /**
      * Listen to the event and notify users based on their job settings
+     * @param {Object}      buildData           Build data emitted with some event from Screwdriver
      * @method notify
-     * @return {Promise}
      */
-    notify() {
-        return this._notify();
+    notify(buildData) {
+        try {
+            this._notify(buildData);
+        } catch (e) {
+            // eslint-disable-next-line no-console
+            console.error(e);
+        }
     }
 
-    _notify() {
-        return Promise.reject('Not implemented');
+    // eslint-disable-next-line no-unused-vars
+    _notify(buildData) {
+        throw new Error('Not implemented');
     }
 }
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "screwdriver-notifications-base",
-  "version": "0.0.1",
+  "version": "1.0.0",
   "description": "Base class for defining the behavior between screwdriver and notifications plugins",
   "main": "index.js",
   "scripts": {
@@ -33,7 +33,8 @@
     "chai": "^3.5.0",
     "eslint": "^3.9.1",
     "eslint-config-screwdriver": "^2.0.9",
-    "jenkins-mocha": "^3.0.0"
+    "jenkins-mocha": "^3.0.0",
+    "sinon": "^2.1.0"
   },
   "dependencies": {},
   "release": {

--- a/test/index.test.js
+++ b/test/index.test.js
@@ -1,16 +1,23 @@
 'use strict';
 
 const assert = require('chai').assert;
+const expect = require('chai').expect;
+const sinon = require('sinon');
 
 describe('index test', () => {
     let instance;
     let NotificationBase;
 
     beforeEach(() => {
+        if (this.sinon == null) {
+            this.sinon = sinon.sandbox.create();
+        } else {
+            this.sinon.restore();
+        }
+        this.sinon.stub(console, 'error');
         // eslint-disable-next-line global-require
         NotificationBase = require('../index');
-
-        instance = new NotificationBase({}, {}, 'build_status');
+        instance = new NotificationBase({});
     });
 
     afterEach(() => {
@@ -21,15 +28,13 @@ describe('index test', () => {
         assert.instanceOf(instance, NotificationBase);
     });
 
-    describe('notify', () => {
-        it('returns not implemented', () =>
-            instance.notify()
-                .then(() => {
-                    assert.fail('you will never get dis');
-                })
-                .catch((err) => {
-                    assert.equal(err, 'Not implemented');
-                })
-        );
+    it('should get events', () => {
+        assert.deepEqual(instance.events, ['build_status']);
+    });
+
+    it('should catch an error', () => {
+        instance.notify({});
+        // eslint-disable-next-line
+        expect(console.error.calledOnce).to.be.true;
     });
 });


### PR DESCRIPTION
### Context
Notification plugins are registered at [registerPlugins](https://github.com/screwdriver-cd/screwdriver/blob/master/lib/registerPlugins.js#L85) and called `notify`, then notification plugin returns a Promise but `registerPlugins` does not use the status of Promise.
In addition, this registration logic can be improved with `registerPlugins`.

### Object
This PR provides to remove Promise and needless params from NotificationBase and to add `get events()` method.

### Misc.
Related: 
- https://github.com/screwdriver-cd/screwdriver/issues/517
- https://github.com/screwdriver-cd/screwdriver/pull/521